### PR TITLE
Use sys.stderr_backup in both save() and restore()

### DIFF
--- a/embroider_params.py
+++ b/embroider_params.py
@@ -745,7 +745,7 @@ def save_stderr():
 def restore_stderr():
     os.dup2(sys.stderr_dup, 2)
     sys.stderr_backup.write(sys.stderr.getvalue())
-    sys.stderr = stderr_backup
+    sys.stderr = sys.stderr_backup
 
 
 # end of class MyFrame


### PR DESCRIPTION
There is no __sys.stderr_backup__ defined in the [Python sys](https://docs.python.org/2/library/sys.html) module.  __save_stderr()__ adds a variable by that name which is a bit unconventional but it does work.  This PR changes __restore_stderr()__ to read that data back in from that same variable.  Without this change, __restore_stderr()__ will probably raise a NameError at runtime because __stderr_backup__ is an undefined name.

flake8 testing of https://github.com/lexelby/inkstitch on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./embroider_params.py:748:18: F821 undefined name 'stderr_backup'
    sys.stderr = stderr_backup
                 ^
```
  