### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -8,6 +8,12 @@ import colorsys
 
 from embroider import patches_to_stitches, stitches_to_polylines, PIXELS_PER_MM
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 class EmbroiderySimulator(wx.Frame):
     def __init__(self, *args, **kwargs):
         stitch_file = kwargs.pop('stitch_file', None)


### PR DESCRIPTION
__xrange()__ was dropped from Python 3 in favor of __range()__.  This PR does not modify Python 2 functionality.
 
At least three other Python 3 issues remain:

flake8 testing of https://github.com/lexelby/inkstitch on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./PyEmb.py:69:16: F821 undefined name 'cmp'
        return cmp(self.as_tuple(), other.as_tuple())
               ^
./embroider.py:717:44: E999 SyntaxError: invalid syntax
        closest = min(outlines, key=lambda (index, outline): outline.distance(point))
                                           ^
./embroider_params.py:646:58: E999 SyntaxError: invalid syntax
        return sorted(nodes_by_class.items(), key=lambda (cls, nodes): cls.__name__)
                                                         ^
```