### PR TITLE
Comment out: pip install -r requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     allow_failures:
         - python: 3.6
 install:
-    - pip install -r requirements.txt
+    # - pip install -r requirements.txt
     - pip install flake8  # pytest  # add another testing frameworks later
 before_script:
     # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
To allow flake8 to run.

For flake8 we do not need requirements.txt loaded.  If you want to do other tests like pytest, nose, etc. you will need to see https://stackoverflow.com/questions/29290011/using-travis-ci-with-wxpython-tests in order to make wxPython play nice with Travis CI.
  