### PR TITLE
add margin around simulator

### DIFF
--- a/embroider_params.py
+++ b/embroider_params.py
@@ -668,7 +668,7 @@ class EmbroiderParams(inkex.Effect):
             getter = 'get_param'
 
         values = filter(lambda item: item is not None,
-                        (getattr(node, getter)(param.name, param.default) for node in nodes))
+                        (getattr(node, getter)(param.name, str(param.default)) for node in nodes))
 
         return values
 

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -335,8 +335,7 @@ class SettingsFrame(wx.Frame):
         self.tabs_factory = kwargs.pop('tabs_factory', [])
         self.cancel_hook = kwargs.pop('on_cancel', None)
         wx.Frame.__init__(self, None, wx.ID_ANY,
-                          "Embroidery Params",
-                          pos=wx.Point(0,0)
+                          "Embroidery Params"
                           )
         self.notebook = wx.Notebook(self, wx.ID_ANY)
         self.tabs = self.tabs_factory(self.notebook)

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -598,7 +598,7 @@ class SettingsFrame(wx.Frame):
     def __set_properties(self):
         # begin wxGlade: MyFrame.__set_properties
         self.SetTitle("Embroidery Parameters")
-        self.notebook.SetMinSize((800, 400))
+        self.notebook.SetMinSize((800, 600))
         self.preset_chooser.SetSelection(-1)
         # end wxGlade
 


### PR DESCRIPTION
This adds a 10px margin around the design in the simulator view (both the Simulate plugin and the Params preview window).  This is useful because otherwise stitches at the edges weren't very visible.  Also, because we're using anti-aliased lines, parts of the drawing did actually extend beyond the canvas previously.

All in all, with the margin it just feels more comfortable.

@wwderw Lots of bugfixes today, so this one's probably worth a test just to make sure I didn't break anything :)