### PR TITLE
don't commit messages.po if only POT-Creation-Date changed

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/bash
 
-make messages.po | grep -v 'is up to date\.$'
-git add messages.po
+make messages.po > /dev/null 2>&1
+
+# This monstrosity asks how many lines changed, but it ignores changes to the
+# "POT-Creation-Date" line.  In other words, if all that's changed is the
+# "POT-Creation-Date", don't bother adding messages.po
+lines_changed=$(git -c difftool.ignorepot.cmd='diff -u -I "POT-Creation-Date" "$LOCAL" "$REMOTE"' difftool -t ignorepot -y messages.po | wc -l)
+
+if [ "$lines_changed" = 0 ]; then
+    git checkout messages.po
+else
+    git add messages.po
+fi


### PR DESCRIPTION
I have a commit hook set to regenerate messages.po on every commit.  However, even if no translatable strings have been added or removed, messages.po changes because xgettext updates the `POT-Creation-Date` line.

This change avoids committing the new messages.po if all that changed is the POT-Creation-Date.