### PR TITLE
fix exploding pes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
 
       export WINEDEBUG=-all
 
-      wget -q https://github.com/lexelby/inkstitch-build-objects/releases/download/v1.0.0/windows-libembroidery.tar.gz
+      wget -q https://github.com/lexelby/inkstitch-build-objects/releases/download/v1.1.0/windows-libembroidery.tar.gz
       tar zxf windows-libembroidery.tar.gz
       rm windows-libembroidery.tar.gz
 

--- a/inkstitch/__init__.py
+++ b/inkstitch/__init__.py
@@ -274,12 +274,13 @@ def write_embroidery_file(file_path, stitch_plan, svg):
         add_thread(pattern, make_thread(color_block.color))
 
         for stitch in color_block:
-            if stitch.stop:
-                # The user specified "STOP after".  "STOP" is the same thing as
-                # a color change, and the user will assign a special color at
-                # the machine that tells it to pause after.  We need to add
-                # another copy of the same color here so that the stitches after
-                # the STOP are still the same color.
+            if stitch.stop and stitch is not color_block.last_stitch:
+                # A STOP stitch that is not at the end of a color block
+                # occurs when the user specified "STOP after".  "STOP" is the
+                # same thing as a color change, and the user will assign a
+                # special color at the machine that tells it to pause after.
+                # We need to add another copy of the same color here so that
+                # the stitches after the STOP are still the same color.
                 add_thread(pattern, make_thread(color_block.color))
 
             flags = get_flags(stitch)


### PR DESCRIPTION
This branch fixes the "exploding pes file" bug, #72. Really, all it does for that bug is pull in the latest version of libembroidery, which picks up the fix I submitted to libembroidery (https://github.com/Embroidermodder/Embroidermodder/pull/108).  I'll need to build the windows version of libembroidery and pull that in as well in order for the Windows version to have the fix.

This PR also fixes a bug I found along the way, where each thread color was added twice to the design file.  This would cause colors to look wrong for formats that have thread colors (PES, HUS, and more, but not DST).

fixes #72 