### PR TITLE
fix grandma

### DIFF
--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -44,7 +44,7 @@ class Input(object):
             if not stitch.flags & END:
                 color_block.add_stitch(stitch.xx * PIXELS_PER_MM, stitch.yy * PIXELS_PER_MM,
                                        jump=stitch.flags & JUMP,
-                                       stop=stitch.flags & STOP,
+                                       color_change=stitch.flags & STOP,
                                        trim=stitch.flags & TRIM)
 
         extents = stitch_plan.extents

--- a/lib/output.py
+++ b/lib/output.py
@@ -32,7 +32,7 @@ def get_flags(stitch):
     if stitch.trim:
         flags |= libembroidery.TRIM
 
-    if stitch.stop:
+    if stitch.color_change:
         flags |= libembroidery.STOP
 
     return flags
@@ -108,13 +108,10 @@ def write_embroidery_file(file_path, stitch_plan, svg):
         add_thread(pattern, make_thread(color_block.color))
 
         for stitch in color_block:
-            if stitch.stop and stitch is not color_block.last_stitch:
-                # A STOP stitch that is not at the end of a color block
-                # occurs when the user specified "STOP after".  "STOP" is the
-                # same thing as a color change, and the user will assign a
-                # special color at the machine that tells it to pause after.
-                # We need to add another copy of the same color here so that
-                # the stitches after the STOP are still the same color.
+            if stitch.stop:
+                # This is the start of the extra color block added by the
+                # "STOP after" handler (see stitch_plan/stop.py).  Assign it
+                # the same color.
                 add_thread(pattern, make_thread(color_block.color))
 
             flags = get_flags(stitch)

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -13,3 +13,6 @@ class Stitch(Point):
 
     def __repr__(self):
         return "Stitch(%s, %s, %s, %s, %s, %s, %s)" % (self.x, self.y, self.color, "JUMP" if self.jump else " ", "TRIM" if self.trim else " ", "STOP" if self.stop else " ", "NO TIES" if self.no_ties else " ")
+
+    def copy(self):
+        return Stitch(self.x, self.y, self.color, self.jump, self.stop, self.trim, self.no_ties)

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -2,17 +2,18 @@ from ..utils.geometry import Point
 
 
 class Stitch(Point):
-    def __init__(self, x, y, color=None, jump=False, stop=False, trim=False, no_ties=False):
+    def __init__(self, x, y, color=None, jump=False, stop=False, trim=False, color_change=False, no_ties=False):
         self.x = x
         self.y = y
         self.color = color
         self.jump = jump
         self.trim = trim
         self.stop = stop
+        self.color_change = color_change
         self.no_ties = no_ties
 
     def __repr__(self):
         return "Stitch(%s, %s, %s, %s, %s, %s, %s)" % (self.x, self.y, self.color, "JUMP" if self.jump else " ", "TRIM" if self.trim else " ", "STOP" if self.stop else " ", "NO TIES" if self.no_ties else " ")
 
     def copy(self):
-        return Stitch(self.x, self.y, self.color, self.jump, self.stop, self.trim, self.no_ties)
+        return Stitch(self.x, self.y, self.color, self.jump, self.stop, self.trim, self.color_change, self.no_ties)

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -23,15 +23,15 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
         if not patch.stitches:
             continue
 
-        if need_trim:
-            process_trim(color_block, patch.stitches[0])
-            need_trim = False
-
         if not color_block.has_color():
             # set the color for the first color block
             color_block.color = patch.color
 
         if color_block.color == patch.color:
+            if need_trim:
+                process_trim(color_block, patch.stitches[0])
+                need_trim = False
+
             # add a jump stitch between patches if the distance is more
             # than the collapse length
             if color_block.last_stitch:

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -59,9 +59,19 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
         if patch.stop_after:
             process_stop(color_block)
 
+    add_jumps(stitch_plan)
     add_ties(stitch_plan)
 
     return stitch_plan
+
+
+def add_jumps(stitch_plan):
+    """Add a JUMP stitch at the start of each color block."""
+
+    for color_block in stitch_plan:
+        stitch = color_block.stitches[0].copy()
+        stitch.jump = True
+        color_block.stitches.insert(0, stitch)
 
 
 class StitchPlan(object):

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -39,10 +39,10 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
                     color_block.add_stitch(patch.stitches[0].x, patch.stitches[0].y, jump=True)
 
         else:
-            # add a color change (only if the last stitch wasn't a "STOP after")
-            if not color_block.last_stitch.stop:
+            # add a color change (only if we didn't just do a "STOP after")
+            if not color_block.last_stitch.color_change:
                 stitch = color_block.last_stitch.copy()
-                stitch.stop = True
+                stitch.color_change = True
                 color_block.add_stitch(stitch)
 
             color_block = stitch_plan.new_color_block()

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -39,8 +39,12 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
                     color_block.add_stitch(patch.stitches[0].x, patch.stitches[0].y, jump=True)
 
         else:
-            # add a color change
-            color_block.add_stitch(color_block.last_stitch.x, color_block.last_stitch.y, stop=True)
+            # add a color change (only if the last stitch wasn't a "STOP after")
+            if not color_block.last_stitch.stop:
+                stitch = color_block.last_stitch.copy()
+                stitch.stop = True
+                color_block.add_stitch(stitch)
+
             color_block = stitch_plan.new_color_block()
             color_block.color = patch.color
 

--- a/lib/stitch_plan/stop.py
+++ b/lib/stitch_plan/stop.py
@@ -17,11 +17,18 @@ def process_stop(color_block):
     """
 
     if len(color_block.stitches) >= 3:
-        color_block.stitches[-3].stop = True
+        # make a copy of the stitch and turn it into a STOP code
+        stitch = color_block.stitches[-3].copy()
+        stitch.stop = True
+
+        # insert it after the stitch
+        color_block.stitches.insert(-2, stitch)
 
     # and also add a color change on this stitch, completing the C00
     # block:
 
-    color_block.stitches[-1].stop = True
+    stitch = color_block.stitches[-1].copy()
+    stitch.stop = True
+    color_block.add_stitch(stitch)
 
     # reference for the above: https://github.com/lexelby/inkstitch/pull/29#issuecomment-359175447

--- a/lib/stitch_plan/stop.py
+++ b/lib/stitch_plan/stop.py
@@ -5,20 +5,29 @@ def process_stop(color_block):
     be useful for applique and similar on multi-needle machines that
     normally would not stop between colors.
 
-    On such machines, the user assigns needles to the colors in the
-    design before starting stitching.  C01, C02, etc are normal
+    In machine embroidery files, there's no such thing as an actual
+    "STOP" instruction.  All that exists is a "color change" command
+    (which libembroidery calls STOP just to be confusing).
+
+    On multi-needle machines, the user assigns needles to the colors in
+    the design before starting stitching.  C01, C02, etc are normal
     needles, but C00 is special.  For a block of stitches assigned
     to C00, the machine will continue sewing with the last color it
     had and pause after it completes the C00 block.
 
-    That means we need to introduce an artificial color change
-    shortly before the current stitch so that the user can set that
-    to C00.  We'll go back 3 stitches and do that:
+    That means we need to add an artificial color change instruction
+    shortly before the current stitch so that the user can set that color
+    block to C00.  We'll go back 3 stitches and mark the start of the C00
+    block:
     """
 
     if len(color_block.stitches) >= 3:
-        # make a copy of the stitch and turn it into a STOP code
+        # make a copy of the stitch and set it as a color change
         stitch = color_block.stitches[-3].copy()
+        stitch.color_change = True
+
+        # mark this stitch as a "stop" so that we can avoid
+        # adding tie stitches in ties.py
         stitch.stop = True
 
         # insert it after the stitch
@@ -28,7 +37,7 @@ def process_stop(color_block):
     # block:
 
     stitch = color_block.stitches[-1].copy()
-    stitch.stop = True
+    stitch.color_change = True
     color_block.add_stitch(stitch)
 
     # reference for the above: https://github.com/lexelby/inkstitch/pull/29#issuecomment-359175447

--- a/lib/stitch_plan/ties.py
+++ b/lib/stitch_plan/ties.py
@@ -34,7 +34,9 @@ def add_ties(stitch_plan):
         need_tie_in = True
         new_stitches = []
         for i, stitch in enumerate(color_block.stitches):
-            is_special = stitch.trim or stitch.jump or stitch.stop
+            # Tie before and after TRIMs, JUMPs, and color changes, but ignore
+            # the fake color change introduced by a "STOP after" (see stop.py).
+            is_special = stitch.trim or stitch.jump or (stitch.color_change and not stitch.stop)
 
             if is_special and not need_tie_in:
                 add_tie_off(new_stitches)

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -16,7 +16,7 @@ def running_stitch(points, stitch_length):
     if len(points) < 2:
         return []
 
-    output = [points[0]]
+    output = []
     segment_start = points[0]
     last_segment_direction = None
 
@@ -59,8 +59,8 @@ def running_stitch(points, stitch_length):
         last_segment_direction = segment_direction
         distance -= segment_length
 
-    # stitch the last point unless we're already almos there
-    if (segment_start - points[-1]).length() > 0.1:
+    # stitch the last point unless we're already almost there
+    if (segment_start - output[-1]).length() > 0.1:
         output.append(segment_start)
 
     return output

--- a/lib/svg/svg.py
+++ b/lib/svg/svg.py
@@ -15,7 +15,7 @@ def color_block_to_point_lists(color_block):
                   point_lists.append([])
                   continue
 
-         if not stitch.jump and not stitch.stop:
+         if not stitch.jump and not stitch.color_change:
               point_lists[-1].append(stitch.as_tuple())
 
     return point_lists


### PR DESCRIPTION
This fixes several bugs in one go:

* add STOP commands as stand-alone stitches rather than attaching to an existing stitch
  * PES requires this, along with possibly other formats
  * fixes #170 
* ignore "TRIM after" at the end of a color block
  * the machine will trim the thread anyway
* fixed two bugs in running stitch
  * the bugs:
    * the first stitch was duplicated
    * the last stitch was omitted
  * these bugs totally screwed up tie-in/tie-off stitches!
* don't do ties around the fake color change of a "STOP after"
* add a JUMP at the start of each color block

I think this should fix a lot of the weirdness that @readymotion saw and mentioned in #170, along with several other bugs I found along the way.  I think it may even fix the extra jump stitches that @danielkschneider has been seeing.

Testing would be especially appreciated since I fixed so many bugs.  A pre-release build of this branch is available [here](https://github.com/lexelby/inkstitch/releases/tag/dev-build-lexelby-fix-grandma).