### PR TITLE
add Expand param for fills

### DIFF
--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-05-01 21:21-0400\n"
+"POT-Creation-Date: 2018-06-01 20:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,6 +42,9 @@ msgid "Max stitch length"
 msgstr ""
 
 msgid "Inset"
+msgstr ""
+
+msgid "Expand"
 msgstr ""
 
 msgid "TRIM after"


### PR DESCRIPTION
This implements the feature we were calling "outset".  I changed the name to "expand" because I don't think the word "outset" can actually be used as an opposite for "inset".

A negative value shrinks instead of expanding, just as a negative value for inset would expand the underlay.  That's in case you really want your underlay to show :) (example: knockdown stitches)

cc @X3msnake 

fixes #178 

