### PR TITLE
fix empty subpath

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -29,12 +29,15 @@ class Patch:
         else:
             raise TypeError("Patch can only be added to another Patch")
 
+    def __len__(self):
+        # This method allows `len(patch)` and `if patch:
+        return len(self.stitches)
+
     def add_stitch(self, stitch):
         self.stitches.append(stitch)
 
     def reverse(self):
         return Patch(self.color, self.stitches[::-1])
-
 
 
 class Param(object):

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -97,6 +97,11 @@ class Stroke(EmbroideryElement):
         # TODO: use inkstitch.stitches.running_stitch
 
         patch = Patch(color=self.color)
+
+        # can't stitch a single point
+        if len(emb_point_list) < 2:
+            return patch
+
         p0 = emb_point_list[0]
         rho = 0.0
         side = 1
@@ -156,6 +161,7 @@ class Stroke(EmbroideryElement):
             else:
                 patch = self.stroke_points(path, self.zigzag_spacing / 2.0, stroke_width=self.stroke_width)
 
-            patches.append(patch)
+            if patch:
+                patches.append(patch)
 
         return patches


### PR DESCRIPTION
fixes #183 

This fixes a crash when a subpath contains only a single point.  I also took advantage of the opportunity to retrofit the code to use a new library routine I wrote previously.  I think this is the last step in the major code reworking I've been doing over the past few months.